### PR TITLE
Fixed a Bug with site-internal links (#)

### DIFF
--- a/webpage2html.py
+++ b/webpage2html.py
@@ -215,7 +215,7 @@ def generate(index, verbose=True, comment=True, keep_script=False, prettify=Fals
         check_alt('onmouseover')
         check_alt('onmouseout')
     for tag in soup(True):
-        if full_url and tag.name == 'a' and tag.has_attr('href'):
+        if full_url and tag.name == 'a' and tag.has_attr('href') and not tag['href'].startswith('#') :
             tag['data-href'] = tag['href']
             tag['href'] = absurl(index, tag['href'])
         if tag.has_attr('style'):


### PR DESCRIPTION
Hi!
I love your script!
Helps me developing embedded webpages for an ESP8266. Thank you!

I applied a fix for page-internal links (e.g. `<a href="#foo">ba</a>` )

Your script substitued it with an abs-url, which broke a lot of the ajax behaviour on my site.

I hope you can use the fix for your main branch!

Best regards,
slevon