### PR TITLE
fix output to file for python3

### DIFF
--- a/webpage2html.py
+++ b/webpage2html.py
@@ -378,7 +378,7 @@ def main():
     rs = generate(args.url, **kwargs)
     if args.output and args.output != '-':
         with open(args.output, 'wb') as f:
-            f.write(rs)
+            f.write(rs.encode())
     else:
         sys.stdout.write(rs)
 


### PR DESCRIPTION
On python3, got the following error without this patch:
```
Traceback (most recent call last):
  File "./webpage2html.py", line 387, in <module>
    main()
  File "./webpage2html.py", line 381, in main
    f.write(rs)
TypeError: a bytes-like object is required, not 'str'
```

Tested this on python3 but may need more work to coexist peacefully with python2.
